### PR TITLE
MatrixQueryBlock fieldId error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Poll Changelog
 
+## 1.7.1 - 2022-05-02
+
+### Fixed
+
+- Field ID error when MatrixQueryBlock returns an array.
+
 ## 1.7.0 - 2021-02-28
 ### Added
 - Now it's possible to add user input text fields to answers. [see the docs](https://io.24hoursmedia.com/craftcms-poll/add-textual-user-input-to-poll-choices)

--- a/src/twigextensions/PollTwigExtension.php
+++ b/src/twigextensions/PollTwigExtension.php
@@ -99,6 +99,9 @@ class PollTwigExtension extends \Twig_Extension
         $fieldId = null;
         if ($matrix) {
             $fieldId = $matrix->fieldId;
+            if (is_array($fieldId)) {
+                $fieldId = array_shift($fieldId);
+            }
             $field = Craft::$app->fields->getFieldById($fieldId);
         } else {
             $field = Craft::$app->fields->getFieldByHandle(


### PR DESCRIPTION
MatrixQueryBlocks can have an array in the fieldId. So this is a hotfix for that. Maybe you should handle this better.

Short question: Is this plugin abandoned? There are a lot of issues and some open PRs. We are thinking about buying it, but we are not sure now. How about Craft 4 support?